### PR TITLE
Backport from cloud-init 0.7.7 to set user uid

### DIFF
--- a/directory_bootstrap/shared/executor.py
+++ b/directory_bootstrap/shared/executor.py
@@ -23,6 +23,9 @@ class Executor(object):
                 cwd=cwd,
                 )
 
-    def check_output(self, argv):
+    def check_output(self, argv, env=None):
         self._messenger.announce_command(argv)
-        return subprocess.check_output(argv, stderr=self._default_stderr)
+        return subprocess.check_output(argv,
+                stderr=self._default_stderr,
+                env=env
+                )

--- a/image_bootstrap/patches/cloud-init-0-7-6-uid.patch
+++ b/image_bootstrap/patches/cloud-init-0-7-6-uid.patch
@@ -1,0 +1,21 @@
+From b05d0d54d29553e1fe1961ccc64da7d0b45016dd Mon Sep 17 00:00:00 2001
+From: Gerhard Muntingh <gerhard@qux.nl>
+Date: Tue, 14 Apr 2015 15:20:39 +0200
+Subject: Add functionality to fixate the uid of a newly added user.
+
+
+diff --git a/cloudinit/distros/__init__.py b/cloudinit/distros/__init__.py
+index ab874b4..b297c78 100644
+--- a/cloudinit/distros/__init__.py
++++ b/cloudinit/distros/__init__.py
+@@ -318,6 +318,7 @@ class Distro(object):
+             "gecos": '--comment',
+             "homedir": '--home',
+             "primary_group": '--gid',
++            "uid": '--uid',
+             "groups": '--groups',
+             "passwd": '--password',
+             "shell": '--shell',
+-- 
+cgit v0.10.2
+

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ if __name__ == '__main__':
                 ],
                 'image_bootstrap': [
                     'patches/cloud-init-0-7-6-pkgbuild.patch',
+                    'patches/cloud-init-0-7-6-uid.patch',
                 ],
             },
             entry_points={


### PR DESCRIPTION
This patches the installed cloud-init 0.7.6 to fix https://bugs.launchpad.net/cloud-init/+bug/1396362, allowing scripts to modify the uid of the newly created cloud user by modifying cloud.cfg. It is simply a matter of applying the (relatively small) patch from https://git.launchpad.net/cloud-init/commit/?id=ab04d7a3e0d210805c9db99bf43eb47808809758