### PR TITLE
Don't exit with code zero on KeyboardInterrupt

### DIFF
--- a/directory_bootstrap/__main__.py
+++ b/directory_bootstrap/__main__.py
@@ -88,7 +88,7 @@ def main():
         fix_output_encoding()
         _main__level_two()
     except KeyboardInterrupt:
-        pass
+        raise
 
 
 if __name__ == '__main__':

--- a/image_bootstrap/__main__.py
+++ b/image_bootstrap/__main__.py
@@ -181,7 +181,7 @@ def main():
         fix_output_encoding()
         _main__level_two()
     except KeyboardInterrupt:
-        pass
+        raise
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Any KeyboardInterrupt bubbling upwards gets eaten away by this pass
statement. Let's re-throw the exception so the calling process (e.g.
script) realizes something went wrong.