### PR TITLE
Install hostname command for archlinux 

### DIFF
--- a/image_bootstrap/distros/arch.py
+++ b/image_bootstrap/distros/arch.py
@@ -222,6 +222,8 @@ class ArchStrategy(DistroStrategy):
         self._install_packages(['sudo'])
 
     def install_cloud_init_and_friends(self):
+        # hostname
+        self._install_packages(['inetutils'])
         self._install_packages(['cloud-init'])
         self.disable_cloud_init_syslog_fix_perms()
         self.install_growpart()


### PR DESCRIPTION
 cloud-init uses `hostname`  command to apply the hostname (if not mistaken).

https://github.com/canonical/cloud-init/blob/6d332e5c8dbfb6521a530b1fa49d73da51efff96/cloudinit/distros/__init__.py#L239

In debian/ubuntu there is a hostname package, but in archlinux is part of  `core/inetutils`. 

This is not about writing the hostname into the correct file (after reboot systemd with hostnamectl fixes this) but when running cloud-init to apply in runtime (first run) the hostname to the machine.

thanks

PS: This is a suggestion PR - feel free to either create a test image, I would be more than happy to test it, or find an alternate solution if you believe this is not the correct way. 
