### PR TITLE
Update gentoo builds

### DIFF
--- a/directory_bootstrap/distros/gentoo.py
+++ b/directory_bootstrap/distros/gentoo.py
@@ -134,7 +134,7 @@ class GentooBootstrapper(DirectoryBootstrapper):
     def _download_stage3(self, stage3_date_str, arch_flavor):
         res = [None, None]
         for target_index, basename in (
-                (1, 'stage3-%s%s-%s.tar.xz.DIGESTS.asc' % (self._architecture, arch_flavor, stage3_date_str)),
+                (1, 'stage3-%s%s-%s.tar.xz.DIGESTS' % (self._architecture, arch_flavor, stage3_date_str)),
                 (0, 'stage3-%s%s-%s.tar.xz' % (self._architecture, arch_flavor, stage3_date_str)),
                 ):
             filename = os.path.join(self._abs_cache_dir, basename)

--- a/image_bootstrap/distros/gentoo.py
+++ b/image_bootstrap/distros/gentoo.py
@@ -15,7 +15,7 @@ from directory_bootstrap.shared.commands import (
 from image_bootstrap.distros.base import DISTRO_CLASS_FIELD, DistroStrategy
 
 _ABS_PACKAGE_USE = '/etc/portage/package.use'
-_ABS_PACKAGE_KEYWORDS = '/etc/portage/package.keywords'
+_ABS_PACKAGE_KEYWORDS = '/etc/portage/package.accept_keywords'
 _ABS_PACKAGE_MASK = '/etc/portage/package.mask'
 _ABS_PACKAGE_UNMASK = '/etc/portage/package.unmask'
 

--- a/image_bootstrap/distros/gentoo.py
+++ b/image_bootstrap/distros/gentoo.py
@@ -486,7 +486,7 @@ class GentooStrategy(DistroStrategy):
         return False
 
     def get_minimum_size_bytes(self):
-        return 7 * 1024**3
+        return 5 * 1024**3
 
     def install_acpid(self):
         self._install_package_atoms(['sys-power/acpid'])

--- a/image_bootstrap/distros/gentoo.py
+++ b/image_bootstrap/distros/gentoo.py
@@ -292,9 +292,6 @@ class GentooStrategy(DistroStrategy):
             os.fchmod(f.fileno(), 0o755)
 
     def install_dhcp_client(self):
-        # Static route support needs dhcpcd <7.0.1 or >=7.0.7
-        # so we unlock >=7.0.7 here (see https://bugs.gentoo.org/659626)
-        self._set_package_keywords('<net-misc/dhcpcd-9999', '**')  # TODO ~arch
         self._install_package_atoms(['net-misc/dhcpcd'])
 
     def install_sudo(self):

--- a/image_bootstrap/distros/gentoo.py
+++ b/image_bootstrap/distros/gentoo.py
@@ -394,7 +394,7 @@ class GentooStrategy(DistroStrategy):
 
     def _configure_kernel__enable_kvm_support(self):
         tasks = dedent("""\
-                # Based on linux-4.0.1/arch/x86/configs/kvm_guest.config
+                # Based on https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/kernel/configs/kvm_guest.config?h=v5.17.3
                 CONFIG_NET=y
                 CONFIG_NET_CORE=y
                 CONFIG_NETDEVICES=y
@@ -416,6 +416,7 @@ class GentooStrategy(DistroStrategy):
                 CONFIG_PARAVIRT=y
                 CONFIG_KVM_GUEST=y
                 CONFIG_VIRTIO=y
+                CONFIG_VIRTIO_MENU=y
                 CONFIG_VIRTIO_PCI=y
                 CONFIG_VIRTIO_BLK=y
                 CONFIG_VIRTIO_CONSOLE=y
@@ -423,6 +424,10 @@ class GentooStrategy(DistroStrategy):
                 CONFIG_9P_FS=y
                 CONFIG_NET_9P=y
                 CONFIG_NET_9P_VIRTIO=y
+                CONFIG_SCSI_LOWLEVEL=y
+                CONFIG_SCSI_VIRTIO=y
+                CONFIG_VIRTIO_INPUT=y
+                CONFIG_DRM_VIRTIO_GPU=y
                 """)
         for line in tasks.split('\n'):
             if not line or line.startswith('#'):


### PR DESCRIPTION
These are some improvements regarding building gentoo with image-bootstrap:

* The linux kernel kvm_config changed (see: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/kernel/configs/kvm_guest.config).

* The correct location of ACCEPT_KEYWORDS changed (see: https://wiki.gentoo.org/wiki/ACCEPT_KEYWORDS).

* The dhcpcd package got fixed after your bugreport (see: https://bugs.gentoo.org/659626).

* In my opinion 5gb is enough for a gentoo base image (the build did work fine multiple times using up <4gb).

* The location/filename of signatures changed (see: https://www.gentoo.org/news/2022/02/17/changed-signatures.html).