### PR TITLE
Really mount /dev, /dev/pts and /sys

### DIFF
--- a/directory_bootstrap/distros/arch.py
+++ b/directory_bootstrap/distros/arch.py
@@ -24,8 +24,8 @@ from directory_bootstrap.shared.resolv_conf import filter_copy_resolv_conf
 SUPPORTED_ARCHITECTURES = ('i686', 'x86_64')
 
 _NON_DISK_MOUNT_TASKS = (
-        ('/dev', ['-o', 'bind'], 'dev'),
-        ('/dev/pts', ['-o', 'bind'], 'dev/pts'),  # for gpgme
+        ('devtmpfs', ['-t', 'devtmpfs'], 'dev'),
+        ('devpts', ['-t', 'devpts'], 'dev/pts'),  # for gpgme
         ('proc', ['-t', 'proc'], 'proc'),  # for pacstrap mountpoint detection
         )
 

--- a/directory_bootstrap/distros/arch.py
+++ b/directory_bootstrap/distros/arch.py
@@ -26,7 +26,7 @@ SUPPORTED_ARCHITECTURES = ('i686', 'x86_64')
 _NON_DISK_MOUNT_TASKS = (
         ('/dev', ['-o', 'bind'], 'dev'),
         ('/dev/pts', ['-o', 'bind'], 'dev/pts'),  # for gpgme
-        ('PROC', ['-t', 'proc'], 'proc'),  # for pacstrap mountpoint detection
+        ('proc', ['-t', 'proc'], 'proc'),  # for pacstrap mountpoint detection
         )
 
 

--- a/image_bootstrap/engine.py
+++ b/image_bootstrap/engine.py
@@ -55,8 +55,8 @@ _CHROOT_SCRIPT_TARGET_DIR = 'root/chroot-scripts/'
 _NON_DISK_MOUNT_TASKS = (
         ('/dev', ['-o', 'bind'], 'dev'),
         ('/dev/pts', ['-o', 'bind'], 'dev/pts'),
-        ('TMPFS', ['-t', 'tmpfs', '-o', 'mode=1777'], 'dev/shm'),
-        ('PROC', ['-t', 'proc'], 'proc'),
+        ('tmpfs', ['-t', 'tmpfs', '-o', 'mode=1777'], 'dev/shm'),
+        ('proc', ['-t', 'proc'], 'proc'),
         ('/sys', ['-o', 'bind'], 'sys'),
         )
 

--- a/image_bootstrap/engine.py
+++ b/image_bootstrap/engine.py
@@ -53,11 +53,11 @@ _MOUNTPOINT_PARENT_DIR = '/mnt'
 _CHROOT_SCRIPT_TARGET_DIR = 'root/chroot-scripts/'
 
 _NON_DISK_MOUNT_TASKS = (
-        ('/dev', ['-o', 'bind'], 'dev'),
-        ('/dev/pts', ['-o', 'bind'], 'dev/pts'),
+        ('devtmpfs', ['-t', 'devtmpfs'], 'dev'),
+        ('devpts', ['-t', 'devpts'], 'dev/pts'),
         ('tmpfs', ['-t', 'tmpfs', '-o', 'mode=1777'], 'dev/shm'),
         ('proc', ['-t', 'proc'], 'proc'),
-        ('/sys', ['-o', 'bind'], 'sys'),
+        ('sysfs', ['-t', 'sysfs'], 'sys'),
         )
 
 _DISK_ID_OFFSET = 440


### PR DESCRIPTION
...instead of just bind-mounting.

When bind-mounting /dev and /dev/pts, parallel execution of image-bootstrap suffers race-conditions, resulting in "target is busy" errors when umount is called for these mount points at the end.