### PR TITLE
Gentoo: Increase minimum size to 8 GiB

### DIFF
--- a/.github/workflows/image-bootstrap-gentoo.yml
+++ b/.github/workflows/image-bootstrap-gentoo.yml
@@ -47,7 +47,7 @@ jobs:
           image-bootstrap --help         ; echo
           image-bootstrap gentoo --help  ; echo
 
-          truncate --size 7g /tmp/disk
+          truncate --size 8g /tmp/disk
           LOOP_DEV="$(sudo losetup --show --find -f /tmp/disk | tee /dev/stderr)"
           echo "LOOP_DEV=${LOOP_DEV}" >> "${GITHUB_ENV}"
 

--- a/image_bootstrap/distros/gentoo.py
+++ b/image_bootstrap/distros/gentoo.py
@@ -490,7 +490,7 @@ class GentooStrategy(DistroStrategy):
         return False
 
     def get_minimum_size_bytes(self):
-        return 5 * 1024**3
+        return 8 * 1024**3
 
     def install_acpid(self):
         self._install_package_atoms(['sys-power/acpid'])


### PR DESCRIPTION
Motivated by https://github.com/hartwork/image-bootstrap/actions/runs/4348459606/jobs/7597012518 , seems to happen from time to time