### PR TITLE
[Arch chroot] Revert pacman to download as `root` user to fix pacstrapping (fixes #510)

### DIFF
--- a/directory_bootstrap/distros/arch.py
+++ b/directory_bootstrap/distros/arch.py
@@ -151,7 +151,10 @@ class ArchBootstrapper(DirectoryBootstrapper):
                 COMMAND_CHROOT,
                 abs_pacstrap_inner_root,
                 'sed',
+                '-e',
                 's/^CheckSpace/#CheckSpace/',
+                '-e',
+                's/^DownloadUser/#DownloadUser/',
                 '-i',
                 '/etc/pacman.conf',
                 ]


### PR DESCRIPTION
Fixes #510

Symptom was:
```
[..]
Pacstrapping into "/tmp/tmp3v4z7for/pacstrap_root/root.x86_64/mnt/arch_root/"...
# chroot /tmp/tmp3v4z7for/pacstrap_root/root.x86_64 pacstrap /mnt/arch_root/
==> Creating install root at /mnt/arch_root/
==> Installing packages to /mnt/arch_root/
:: Synchronizing package databases...
error: could not open file /mnt/arch_root/var/lib/pacman/sync/download-XM1mgm/core.db.part: Permission denied
error: failed to setup a download payload for core.db
error: failed to synchronize all databases (failed to retrieve some files)
==> ERROR: Failed to install packages to new root
[..]
```

Upstream issue:
https://gitlab.archlinux.org/archlinux/arch-install-scripts/-/issues/68