### PR TITLE
[Arch OpenStack] Adapt to rename of `cloud-init` systemd service in cloud-init >=24.3 (fixes #515)

### DIFF
--- a/image_bootstrap/distros/arch.py
+++ b/image_bootstrap/distros/arch.py
@@ -258,7 +258,7 @@ class ArchStrategy(DistroStrategy):
                 'systemd-resolved',  # for nameserver IPs from DHCP
                 'sshd',
                 'cloud-init-local',
-                'cloud-init',
+                'cloud-init-network',
                 'cloud-config',
                 'cloud-final',
                 ])


### PR DESCRIPTION
Fixes #515