### PR TITLE
Arch: Enable systemd service `cloud-init-main`

### DIFF
--- a/image_bootstrap/distros/arch.py
+++ b/image_bootstrap/distros/arch.py
@@ -255,6 +255,7 @@ class ArchStrategy(DistroStrategy):
                 'systemd-networkd',
                 'systemd-resolved',  # for nameserver IPs from DHCP
                 'sshd',
+                'cloud-init-main',
                 'cloud-init-local',
                 'cloud-init-network',
                 'cloud-config',


### PR DESCRIPTION
so that cloud-init can use `cidata` labeled filesystems again as a NoCloud datasource if provided during boot. see https://github.com/hartwork/image-bootstrap/issues/515#issuecomment-2868461821