### PR TITLE
Fix CI / void: Move from musl to glibc for the moment

### DIFF
--- a/directory_bootstrap/distros/void.py
+++ b/directory_bootstrap/distros/void.py
@@ -83,7 +83,7 @@ class VoidBootstrapper(DirectoryBootstrapper):
             self._executor.check_call([
                     xbps_install,
                     '--rootdir', self._abs_target_dir,
-                    '--repository=https://repo-default.voidlinux.org/current/musl',
+                    '--repository=https://repo-default.voidlinux.org/current',
                     '--sync', '--yes',
                     'base-system',
                     ], cwd=abs_temp_dir)


### PR DESCRIPTION
.. because the musl repository lacks file `x86_64-repodata` which `xbps-install.static` expects (but it has file `x86_64-musl-repodata` with "musl" instead). Could be a configuration thing, needs a closer look some time.