### PR TITLE
alpine: Avoid alpine-minirootfs 3.23.4 due to missing `.asc` download

### DIFF
--- a/directory_bootstrap/distros/alpine.py
+++ b/directory_bootstrap/distros/alpine.py
@@ -52,7 +52,13 @@ class AlpineBootstrapper(DirectoryBootstrapper):
         if match is None:
             raise VersionException('Could not determine latest release version.')
 
-        return match.group('version')
+        version = match.group('version')
+
+        # Workaround mirrors missing "alpine-minirootfs-3.23.4-x86_64.tar.gz.asc" file
+        if version == "3.23.4":
+            version = "3.23.3"
+
+        return version
 
     @staticmethod
     def _parse_version(version_str):


### PR DESCRIPTION
3.23.3 does have a .asc file but 3.23.4 does not:
```
alpine-minirootfs-3.23.3-x86_64.tar.gz             27-Jan-2026 21:19      4M
alpine-minirootfs-3.23.3-x86_64.tar.gz.asc         27-Jan-2026 23:25     833
alpine-minirootfs-3.23.3-x86_64.tar.gz.sha256      27-Jan-2026 21:19     105
alpine-minirootfs-3.23.3-x86_64.tar.gz.sha512      27-Jan-2026 21:19     169
alpine-minirootfs-3.23.4-x86_64.tar.gz             15-Apr-2026 04:51      4M
alpine-minirootfs-3.23.4-x86_64.tar.gz.sha256      15-Apr-2026 04:51     105
alpine-minirootfs-3.23.4-x86_64.tar.gz.sha512      15-Apr-2026 04:51     169
```